### PR TITLE
Update anime.mdx [2 word spelling fixes]

### DIFF
--- a/docs/resources/anime.mdx
+++ b/docs/resources/anime.mdx
@@ -198,11 +198,11 @@ A collection of the show's associated sagas.
 ```js title="Saga's object structure"
 {
   // Map of strings
-  // Contains the saga's title in variuos localizations
+  // Contains the saga's title in various localizations
   "titles": {}
 
   // Map of strings
-  // Contains the saga's description in variuos localizations
+  // Contains the saga's description in various localizations
   "descriptions": {}
 
   // Integer


### PR DESCRIPTION
In the 'sagas' attribute description for the Anime resource, the word 'variuos' is used twice (comments above "titles" and "descriptions") but it should be spelled 'various'.